### PR TITLE
优化序数词翻译

### DIFF
--- a/script/dev/atcoder-better.user.js
+++ b/script/dev/atcoder-better.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         Atcoder Better!
 // @namespace    https://greasyfork.org/users/747162
-// @version      1.17.8
+// @version      1.17.9
 // @description  一个适用于 AtCoder 的 Tampermonkey 脚本，增强功能与界面。
 // @author       北极小狐
 // @match        *://atcoder.jp/*
@@ -3805,7 +3805,8 @@ class TextBlockReplacer {
                         break;
                 }
                 text = text.replace(match, replacement);
-                if (isOrdinal(match)) this.replacements.set(id, ordinalTranslation(match));
+                if (isOrdinal(match) && OJBetter.translation.targetLang === 'zh') 
+                    this.replacements.set(id, ordinalTranslation(match));
                 else this.replacements.set(id, match);
             }
         } catch (e) { }
@@ -8570,8 +8571,10 @@ async function translateProblemStatement(text, element_node, is_comment, overrid
             text = textBlockReplacer.replace(text, regex);
         } else if (realTransServer != "openai") {
             // 使用GPT翻译时不必替换latex公式
-            // 匹配行内公式时对序数词特殊判断以优化翻译
-            const regex = /\$\$([^]*?)\$\$|\$(\\\$|[^\$])*?\$(st|nd|rd|th)?/g;
+            let regex = /\$\$([^]*?)\$\$|\$(\\\$|[^\$])*?\$/g;
+            // 目标语言是中文时，匹配行内公式时对序数词特殊判断以优化翻译
+            if (OJBetter.translation.targetLang === 'zh') 
+                regex = /\$\$([^]*?)\$\$|\$(\\\$|[^\$])*?\$(st|nd|rd|th)?/g;
             text = textBlockReplacer.replace(text, regex);
 
             // 替换行间代码块```
@@ -8658,7 +8661,8 @@ async function translateProblemStatement(text, element_node, is_comment, overrid
             { pattern: /(_[\u4e00-\u9fa5]+_)([\u4e00-\u9fa5]+)/g, replacement: " $1 $2" },
             { pattern: /（([\s\S]*?)）/g, replacement: "($1)" }, // 中文（）
             // { pattern: /：/g, replacement: ":" }, // 中文：
-            { pattern: /\*\* (.*?) \*\*/g, replacement: "\*\*$1\*\*" } // 加粗
+            { pattern: /\*\* (.*?) \*\*/g, replacement: "\*\*$1\*\*" }, // 加粗
+            { pattern: /\* \*(.*?)\* \*/g, replacement: "\*\*$1\*\*" } // 加粗
         ];
         mdRuleMap.forEach(({ pattern, replacement }) => {
             text = text.replace(pattern, replacement);

--- a/script/dev/atcoder-better.user.js
+++ b/script/dev/atcoder-better.user.js
@@ -3775,6 +3775,15 @@ class TextBlockReplacer {
      * @returns {string} 替换后的文本
      */
     replace(text, regex) {
+        // 优化序数词翻译
+        let isOrdinal = (text) => {
+            return Boolean(text.match(/\$\d+?\$[(st)(nd)(rd)(th)]/g));
+        }
+        let ordinalTranslation = (text) => {
+            return '第 ' + text.match(/\$\d+?\$/g)[0] + ' 个';
+        };
+
+
         this.matches = text.match(regex) || [];
         try {
             for (let i = 0; i < this.matches.length; i++) {
@@ -3796,7 +3805,8 @@ class TextBlockReplacer {
                         break;
                 }
                 text = text.replace(match, replacement);
-                this.replacements.set(id, match);
+                if (isOrdinal(match)) this.replacements.set(id, ordinalTranslation(match));
+                else this.replacements.set(id, match);
             }
         } catch (e) { }
         return text;
@@ -3828,7 +3838,8 @@ class TextBlockReplacer {
                 const offset = args[args.length - 3]; // offset是replace方法的倒数第三个参数
                 let leftSpace = "", rightSpace = "";
                 if (!/\s/.test(textCopy[offset - 1])) leftSpace = " ";
-                if (!/\s/.test(textCopy[offset + match.length])) rightSpace = " ";
+                if (!/\s/.test(textCopy[offset + match.length]) && /[\x20-\x7E]/.test(replacement[replacement.length - 1]))
+                    rightSpace = " ";
                 return leftSpace + replacement + rightSpace;
             });
         };
@@ -8559,7 +8570,8 @@ async function translateProblemStatement(text, element_node, is_comment, overrid
             text = textBlockReplacer.replace(text, regex);
         } else if (realTransServer != "openai") {
             // 使用GPT翻译时不必替换latex公式
-            const regex = /\$\$([^]*?)\$\$|\$(\\\$|[^\$])*?\$/g;
+            // 匹配行内公式时对序数词特殊判断以优化翻译
+            const regex = /\$\$([^]*?)\$\$|\$(\\\$|[^\$])*?\$(st|nd|rd|th)?/g;
             text = textBlockReplacer.replace(text, regex);
 
             // 替换行间代码块```

--- a/script/dev/codeforces-better.user.js
+++ b/script/dev/codeforces-better.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         Codeforces Better!
 // @namespace    https://greasyfork.org/users/747162
-// @version      1.76.15
+// @version      1.76.16
 // @author       北极小狐
 // @match        *://*.codeforces.com/*
 // @match        *://*.codeforc.es/*
@@ -3945,7 +3945,8 @@ class TextBlockReplacer {
                         break;
                 }
                 text = text.replace(match, replacement);
-                if (isOrdinal(match)) this.replacements.set(id, ordinalTranslation(match));
+                if (isOrdinal(match) && OJBetter.translation.targetLang === 'zh') 
+                    this.replacements.set(id, ordinalTranslation(match));
                 else this.replacements.set(id, match);
             }
         } catch (e) { }
@@ -8850,8 +8851,10 @@ async function translateProblemStatement(text, element_node, is_comment, overrid
             text = textBlockReplacer.replace(text, regex);
         } else if (realTransServer != "openai") {
             // 使用GPT翻译时不必替换latex公式
-            // 匹配行内公式时对序数词特殊判断以优化翻译
-            const regex = /\$\$([^]*?)\$\$|\$(\\\$|[^\$])*?\$(st|nd|rd|th)?/g;
+            let regex = /\$\$([^]*?)\$\$|\$(\\\$|[^\$])*?\$/g;
+            // 目标语言是中文时，匹配行内公式时对序数词特殊判断以优化翻译
+            if (OJBetter.translation.targetLang === 'zh') 
+                regex = /\$\$([^]*?)\$\$|\$(\\\$|[^\$])*?\$(st|nd|rd|th)?/g;
             text = textBlockReplacer.replace(text, regex);
 
             // 替换行间代码块```
@@ -8937,7 +8940,8 @@ async function translateProblemStatement(text, element_node, is_comment, overrid
             { pattern: /(_[\u4e00-\u9fa5]+_)([\u4e00-\u9fa5]+)/g, replacement: " $1 $2" },
             { pattern: /（([\s\S]*?)）/g, replacement: "($1)" }, // 中文（）
             // { pattern: /：/g, replacement: ":" }, // 中文：
-            { pattern: /\*\* (.*?) \*\*/g, replacement: "\*\*$1\*\*" } // 加粗
+            { pattern: /\*\* (.*?) \*\*/g, replacement: "\*\*$1\*\*" }, // 加粗
+            { pattern: /\* \*(.*?)\* \*/g, replacement: "\*\*$1\*\*" } // 加粗
         ];
         mdRuleMap.forEach(({ pattern, replacement }) => {
             text = text.replace(pattern, replacement);


### PR DESCRIPTION
在题面中经常出现形如 `$2$nd $6$st` 这样夹带 LaTeX 的序数词，直接替换后不能被翻译软件正常翻译，例如 deepl 往往翻译成 “{}的第{}个”有道会把 `{}nd` 翻译成 “{}和”等。但经试验，如果匹配整个序数词再直接替换成“第 $$ 个”可以有正确的效果。

因此，我对源码进行了一点修改，将序数词整体替换为“第 $$ 个”。