### PR TITLE
更改 Main 的翻译

### DIFF
--- a/resources/subs/codeforces-better.json
+++ b/resources/subs/codeforces-better.json
@@ -255,7 +255,7 @@
                 "Mashups": "组合混搭",
                 "Posts": "帖子",
                 "Comments": "回复",
-                "Main": "主要的",
+                "Main": "主题库",
                 "Settings": "设置",
                 "Lists": "列表",
                 "General": "基本",


### PR DESCRIPTION
Main 在 CF 界面中应该翻译为“主题库”（和 ACMSGURU 并列）。