### PR TITLE
修复分段翻译翻译间隔

### DIFF
--- a/script/dev/codeforces-better.user.js
+++ b/script/dev/codeforces-better.user.js
@@ -8807,6 +8807,7 @@ async function transTask(button, element, type, is_comment, overrideTrans) {
         count,
         overrideTrans
       );
+      await new Promise(resolve => setTimeout(resolve, OJBetter.translation.waitTime));
     }
   } else if (OJBetter.translation.comment.transMode == "2") {
     // 选段翻译

--- a/script/dev/codeforces-better.user.js
+++ b/script/dev/codeforces-better.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         Codeforces Better!
 // @namespace    https://greasyfork.org/users/747162
-// @version      1.76.17
+// @version      1.76.18
 // @author       北极小狐
 // @match        *://*.codeforces.com/*
 // @match        *://*.codeforc.es/*


### PR DESCRIPTION
#197 
先把这个问题修复了。
看起来 ·OJBetter.translation.waitTime· 这个变量只在 ·class TaskQueue· 里被用到了。但是我怀疑在分段翻译的过程中并没有调用 addTask。