### PR TITLE
fix(Codeforces & Atcoder):在调用远程查询 API 余量时，确保只有在非 GET 方法中才添加 body

### DIFF
--- a/script/dev/atcoder-better.user.js
+++ b/script/dev/atcoder-better.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         Atcoder Better!
 // @namespace    https://greasyfork.org/users/747162
-// @version      1.17.12
+// @version      1.17.13
 // @description  一个适用于 AtCoder 的 Tampermonkey 脚本，增强功能与界面。
 // @author       北极小狐
 // @match        *://atcoder.jp/*
@@ -13880,8 +13880,12 @@ async function queryServerBalance(quotaConfig) {
         headers: {
             ...Object.assign({}, ...quotaConfig.header)
         },
-        data: JSON.stringify({ ...Object.assign({}, ...quotaConfig.data) })
     };
+
+    // 只有在 method 不是 'GET' 时才添加 data
+    if (requestOptions.method.toUpperCase() !== 'GET' && quotaConfig.data) {
+        requestOptions.data = JSON.stringify({ ...Object.assign({}, ...quotaConfig.data) });
+    }
 
     // 发送请求并返回 Promise
     return OJB_GMRequest(requestOptions).then(response => {

--- a/script/dev/codeforces-better.user.js
+++ b/script/dev/codeforces-better.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         Codeforces Better!
 // @namespace    https://greasyfork.org/users/747162
-// @version      1.76.18
+// @version      1.76.19
 // @author       北极小狐
 // @match        *://*.codeforces.com/*
 // @match        *://*.codeforc.es/*
@@ -16604,8 +16604,12 @@ async function queryServerBalance(quotaConfig) {
     headers: {
       ...Object.assign({}, ...quotaConfig.header),
     },
-    data: JSON.stringify({ ...Object.assign({}, ...quotaConfig.data) }),
   };
+
+  // 只有在 method 不是 'GET' 时才添加 data
+  if (requestOptions.method.toUpperCase() !== 'GET' && quotaConfig.data) {
+    requestOptions.data = JSON.stringify({ ...Object.assign({}, ...quotaConfig.data) });
+  }
 
   // 发送请求并返回 Promise
   return OJB_GMRequest(requestOptions)


### PR DESCRIPTION
## 问题 
进行API剩余额度查询时，报错：查询失败 An error occurred during the request.

![Pasted image 20241218151539](https://github.com/user-attachments/assets/f5a66658-3f1e-4596-95ff-91d6c09061b3)

## 抛出的错误信息
错误信息为：Failed to execute 'fetch' on 'WorkerGlobalScope': Request with GET/HEAD method cannot have body.

![image](https://github.com/user-attachments/assets/4bbfa597-db21-4424-be00-4a6c1af7b286)

## 定位错误
定位到代码中的这个位置
![Pasted image 20241218151832](https://github.com/user-attachments/assets/2ab35716-eef2-40fe-b7af-7361a745d4f8)


## 原因
Fetch 协议并不支持GET请求中携带Body

[RFC 7231](https://datatracker.ietf.org/doc/html/rfc7231#section-4.3.1)标准指出

```
   A payload within a GET request message has no defined semantics;
   sending a payload body on a GET request might cause some existing
   implementations to reject the request.
   
   GET 请求消息中的有效载荷没有明确定义的语义；  
   在 GET 请求中发送有效载荷可能会导致一些现有的实现拒绝该请求。
```

尽管有些协议支持在Get请求中携带Body，但是这并不是符合规范的。

所以，如果请求方式是GET，那么没必要添加Body


