### PR TITLE
修改若干翻译

### DIFF
--- a/resources/subs/codeforces-better.json
+++ b/resources/subs/codeforces-better.json
@@ -919,6 +919,16 @@
                 "Click": "点击",
                 "to see test details": "查看测试详情"
             }
+        },
+        ".unrated-allowed": {
+            "class": [
+                ".unrated-allowed"
+            ],
+            "description": "",
+            "isStrict": false,
+            "rules": {
+                "Unrated allowed": "允许未评级报名"
+            }
         }
     },
     "InputValueReplacements": {
@@ -1002,6 +1012,7 @@
         }
     }
 }
+
 
 
 


### PR DESCRIPTION
（commits这么多是我在调试...）

1. 在“比赛”菜单右边的”筛选过去的比赛“里面，加了个翻译”在比赛标题与编写者中搜索“。
    - 注：因为加了一个class=shiftUp的替换规则，不确定在其他地方会不会出问题（但大概率不会）。
2. 在未登录的时候打开比赛或题目界面，添加了对于右边的“练习？”底下的英文的翻译。
    - 跟英文原文意思有一些区别，加了我自己的理解。

之后还会加对于“Unrated allowed”的翻译。