### PR TITLE
fix: 匹配Codeforces中PP的大小写

### DIFF
--- a/script/dev/codeforces-better.user.js
+++ b/script/dev/codeforces-better.user.js
@@ -11903,7 +11903,7 @@ const StatusAcronyms = {
   "Partial result:": "PC",
   Running: "PENDING",
   "In queue": "INQUEUE",
-  "Pretests Passed": "PREPASS",
+  "Pretests passed": "PREPASS",
 };
 
 /**
@@ -17253,5 +17253,6 @@ if (document.readyState === "loading") {
     location.reload();
   }
 }
+
 
 


### PR DESCRIPTION
`CodeForces` 中的 `passed` 是小写，原来的大写会匹配失败。