### PR TITLE
进行了一堆修改

### DIFF
--- a/resources/subs/codeforces-better.json
+++ b/resources/subs/codeforces-better.json
@@ -116,9 +116,9 @@
                 "Settings": "设置",
                 "Blog": "博客",
                 "Teams": "队伍",
-                "Submissions": "提交",
+                "Submissions": "提交记录",
                 "Favourites": "收藏",
-                "Problemsetting": "问题设置",
+                "Problemsetting": "参与编写的问题",
                 "Groups": "团体",
                 "Talks": "私信",
                 "Contests": "比赛"


### PR DESCRIPTION
**这次Contribution的修改内容及其的多**，目前只在部分比如名称里有`Problems`、`Enter`等关键词的题目及其题目列表、提交记录列表里做过测试，具体是否稳定无法100%确认，**欢迎其他贡献者提出问题并进行修改！**

更改包括把表头的翻译换到`.first-row`元素替换规则里面统一替换，尽量避免`.datatable`元素一刀切导致题目名称也被翻译（我相信很多人已经忍这个bug好久了，之后我还会看看AtCoder会不会有这个问题👀）。

另外还添加了很多翻译，比如主页侧边栏“虚拟参赛”的翻译等。

感谢作者提供的IndexDB数据库导入导出，极大地方便了开发者测试翻译修改效果（因为Github的Raw更新有时候不及时）。