### PR TITLE
AtCoder规则更新

### DIFF
--- a/resources/subs/atcoder-better.json
+++ b/resources/subs/atcoder-better.json
@@ -779,7 +779,7 @@
                 "It is prohibited to use generative AI in ongoing AtCoder contests. Please refer to the following rules for more details.": "禁止在正在进行的 AtCoder 比赛中使用生成式 AI。请参考下面的规则了解详情。",
                 "AtCoder Rules against Generative AI - Version 20251003": "AtCoder 对于生成式 AI 的规定 - 20251003 版本",
                 "Please note that the rules were updated on October 3\\, 2025.": "注意此规则已于 2025 年 10 月 3 日更新。",
-                " For details\\, please see ": "详情请见",
+                "For details\\, please see ": "详情请见",
                 "\\.": "。",
                 "participant": "参与者",
                 "Registered": "已报名",
@@ -888,6 +888,7 @@
     },
     "dynamicReplacements": {}
 }
+
 
 
 


### PR DESCRIPTION
比赛规则又双叒叕更新了，现在能够正确显示“详情请见这篇文章。”翻译了