### PR TITLE
[fix]修复 issue #390，完善代码语言识别

### DIFF
--- a/script/dev/atcoder-better.user.js
+++ b/script/dev/atcoder-better.user.js
@@ -4424,7 +4424,7 @@ const LANGUAGE_ALIASES = {
 const COMPETITIVE_LANGUAGES = new Set([
     'cpp','python','java','rust','csharp',
     'ruby','kotlin','haskell','go','javascript',
-    'typescript','swift','swift','d','php','julia'
+    'typescript','swift','d','php','julia'
 ]);
 
 /**

--- a/script/dev/atcoder-better.user.js
+++ b/script/dev/atcoder-better.user.js
@@ -1795,7 +1795,7 @@ async function beautifyPreBlocksWithMonaco() {
         const code = OJB_getCodeFromPre(pre); // 获取 <pre> 标签中的代码
         if (!code) return;
 
-        const language = OJB_codeLangDetect(code,pre); // 检测代码语言
+        const language = OJB_codeLangDetect(code, pre); // 检测代码语言
         const container = document.createElement('div'); // 创建一个用于 Monaco 编辑器的容器
         const lineCount = code.split('\n').length; // 计算代码的行数
 
@@ -4410,21 +4410,21 @@ const LANGUAGE_ALIASES = {
     'js': 'javascript', 'node': 'javascript',
     'cs': 'csharp', 'c#': 'csharp',
     'golang': 'go',
-    'rs': 'rust', 
-    'rb': 'ruby', 
+    'rs': 'rust',
+    'rb': 'ruby',
     'kt': 'kotlin',
     'hs': 'haskell',
     'jl': 'julia',
     'ts': 'typescript',
-    'md':'markdown'
+    'md': 'markdown'
 };
 
 // 白名单，只保留算法竞赛常用的语言，避免一些奇奇怪怪的匹配
 
 const COMPETITIVE_LANGUAGES = [
-    'cpp','python','java','rust','csharp',
-    'ruby','kotlin','haskell','go','javascript',
-    'typescript','swift','d','php','julia'
+    'cpp', 'python', 'java', 'rust', 'csharp',
+    'ruby', 'kotlin', 'haskell', 'go', 'javascript',
+    'typescript', 'swift', 'd', 'php', 'julia'
 ];
 
 /**
@@ -4451,10 +4451,10 @@ function detectLanguageFromDOM(element) {
         const result = normalizeLang(match[1]);
         if (result) return result;
     }
-    
+
     // 3. 从 <pre><code> 里获取的 language-xxx 或 lang-xxx
 
-    const ccls = element.querySelector('code').className || '';
+    const ccls = element.querySelector('code')?.className || '';
     const cmatch = ccls.match(/(?:^|\s)(?:lang(?:uage)?-)(\S+)/i);
     if (cmatch) {
         const result = normalizeLang(cmatch[1]);
@@ -4470,8 +4470,9 @@ function detectLanguageFromDOM(element) {
  * @returns 格式化后，Monaco Editor 认识的语言名
  */
 function normalizeLang(raw) {
+    if (!raw) return null;
     const normalized = raw.trim().toLowerCase();
-    if(monaco.languages.getLanguages().map(l => l.id).includes(normalized)) return normalized;
+    if (monaco.languages.getLanguages().map(l => l.id).includes(normalized)) return normalized;
     return LANGUAGE_ALIASES[normalized] || null;
 }
 
@@ -4481,8 +4482,8 @@ function normalizeLang(raw) {
  * @returns 可能的代码语言，准确度取决于 HLJS
  */
 function whitelistFallback(code) {
-    const result = hljs.highlightAuto(code,COMPETITIVE_LANGUAGES);
-    return result.language||'plaintext';
+    const result = hljs.highlightAuto(code, COMPETITIVE_LANGUAGES);
+    return result.language || 'plaintext';
 }
 
 
@@ -4498,7 +4499,7 @@ function OJB_codeLangDetect(code, element) {
     if (fromDOM) return fromDOM;
 
     // 第二层：白名单兜底
-    return  whitelistFallback(code);
+    return whitelistFallback(code);
 }
 
 /**

--- a/script/dev/atcoder-better.user.js
+++ b/script/dev/atcoder-better.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         Atcoder Better!
 // @namespace    https://greasyfork.org/users/747162
-// @version      1.23.1
+// @version      1.23.2
 // @description  一个适用于 AtCoder 的 Tampermonkey 脚本，增强功能与界面。
 // @author       北极小狐
 // @match        *://atcoder.jp/*

--- a/script/dev/atcoder-better.user.js
+++ b/script/dev/atcoder-better.user.js
@@ -4421,11 +4421,11 @@ const LANGUAGE_ALIASES = {
 
 // 白名单，只保留算法竞赛常用的语言，避免一些奇奇怪怪的匹配
 
-const COMPETITIVE_LANGUAGES = new Set([
+const COMPETITIVE_LANGUAGES = [
     'cpp','python','java','rust','csharp',
     'ruby','kotlin','haskell','go','javascript',
-    'typescript','swift','swift','d','php','julia'
-]);
+    'typescript','swift','d','php','julia'
+];
 
 /**
  * 尝试从 DOM 中获取代码语言
@@ -4481,18 +4481,8 @@ function normalizeLang(raw) {
  * @returns 可能的代码语言，准确度取决于 HLJS
  */
 function whitelistFallback(code) {
-    const result = hljs.highlightAuto(code);
-
-    // 按 relevance 降序，找第一个在白名单里的语言
-    const languages = result.language
-        ? [result.language, ...(result.secondBest ? [result.secondBest.language] : [])]
-        : [];
-
-    for (const lang of languages) {
-        if (COMPETITIVE_LANGUAGES.has(lang)) return lang;
-    }
-
-    return 'plaintext';
+    const result = hljs.highlightAuto(code,COMPETITIVE_LANGUAGES);
+    return result.language||'plaintext';
 }
 
 

--- a/script/dev/atcoder-better.user.js
+++ b/script/dev/atcoder-better.user.js
@@ -1795,7 +1795,7 @@ async function beautifyPreBlocksWithMonaco() {
         const code = OJB_getCodeFromPre(pre); // 获取 <pre> 标签中的代码
         if (!code) return;
 
-        const language = OJB_codeLangDetect(code); // 检测代码语言
+        const language = OJB_codeLangDetect(code,pre); // 检测代码语言
         const container = document.createElement('div'); // 创建一个用于 Monaco 编辑器的容器
         const lineCount = code.split('\n').length; // 计算代码的行数
 
@@ -4400,14 +4400,115 @@ function OJB_getCodeFromPre(element) {
     return result;
 }
 
+
+// =================处理代码块语言===============
+// 映射表，考虑一些作者会写出奇奇怪怪的语言名，先做一个映射；有些是平台自动生成的，有些单纯是防止作者写奇奇怪怪的名称
+
+const LANGUAGE_ALIASES = {
+    'py': 'python', 'python3': 'python', 'py3': 'python',
+    'c++': 'cpp', 'c_cpp': 'cpp', 'cc': 'cpp', 'cxx': 'cpp', 'cplusplus': 'cpp',
+    'js': 'javascript', 'node': 'javascript',
+    'cs': 'csharp', 'c#': 'csharp',
+    'golang': 'go',
+    'rs': 'rust', 
+    'rb': 'ruby', 
+    'kt': 'kotlin',
+    'hs': 'haskell',
+    'jl': 'julia',
+    'ts': 'typescript',
+    'md':'markdown'
+};
+
+// 白名单，只保留算法竞赛常用的语言，避免一些奇奇怪怪的匹配
+
+const COMPETITIVE_LANGUAGES = new Set([
+    'cpp','python','java','rust','csharp',
+    'ruby','kotlin','haskell','go','javascript',
+    'typescript','swift','swift','d','php','julia'
+]);
+
+/**
+ * 尝试从 DOM 中获取代码语言
+ * @param {htmlElement | null} element 所在的 <pre> 标签
+ * @returns {string|null} 从 DOM 中获取的语言
+ */
+function detectLanguageFromDOM(element) {
+    if (!element) return null;
+
+    // 1. data-ace-mode（AtCoder Submission）
+    // Atcoder submission 中 通过 <pre> 上的 data-ace-mode 来存语言类型
+    const ace = element.dataset?.aceMode;
+    if (ace) {
+        const result = normalizeLang(ace);
+        if (result) return result;
+    }
+
+    // 2. class 里的 language-xxx 或 lang-xxx
+    // 与 HighlightJS 保持一致或类似的做法，存在一个 lang(uage)- 表示语言
+    const cls = element.className || '';
+    const match = cls.match(/(?:^|\s)(?:lang(?:uage)?-)(\S+)/i);
+    if (match) {
+        const result = normalizeLang(match[1]);
+        if (result) return result;
+    }
+    
+    // 3. 从 <pre><code> 里获取的 language-xxx 或 lang-xxx
+
+    const ccls = element.querySelector('code').className || '';
+    const cmatch = ccls.match(/(?:^|\s)(?:lang(?:uage)?-)(\S+)/i);
+    if (cmatch) {
+        const result = normalizeLang(cmatch[1]);
+        if (result) return result;
+    }
+
+    return null;
+}
+
+/**
+ * 格式化语言名
+ * @param {string | null} raw 未加处理的，直接从 DOM 中获取的语言名
+ * @returns 格式化后，Monaco Editor 认识的语言名
+ */
+function normalizeLang(raw) {
+    const normalized = raw.trim().toLowerCase();
+    if(monaco.languages.getLanguages().map(l => l.id).includes(normalized)) return normalized;
+    return LANGUAGE_ALIASES[normalized] || null;
+}
+
+/**
+ *  第二层：检测白名单中的语言，避免 HLJS 匹配一些奇怪的语言
+ * @param {string} code 需要检查的代码
+ * @returns 可能的代码语言，准确度取决于 HLJS
+ */
+function whitelistFallback(code) {
+    const result = hljs.highlightAuto(code);
+
+    // 按 relevance 降序，找第一个在白名单里的语言
+    const languages = result.language
+        ? [result.language, ...(result.secondBest ? [result.secondBest.language] : [])]
+        : [];
+
+    for (const lang of languages) {
+        if (COMPETITIVE_LANGUAGES.has(lang)) return lang;
+    }
+
+    return 'plaintext';
+}
+
+
 /**
  * 判断代码的语言
  * @param {string} code 代码文本
+ * @param {HTMLElement | null} element 代码所在的 <pre> 标签
  * @returns {string} 可能的语言
  */
-function OJB_codeLangDetect(code) {
-    result = hljs.highlightAuto(code);
-    return result.language;
+function OJB_codeLangDetect(code, element) {
+    // 第一层：DOM 优先
+    const fromDOM = detectLanguageFromDOM(element);
+    if (fromDOM) return fromDOM;
+
+    // 第二层：白名单兜底
+    return  whitelistFallback(code);
 }
 
 /**

--- a/script/dev/codeforces-better.user.js
+++ b/script/dev/codeforces-better.user.js
@@ -5196,11 +5196,11 @@ const LANGUAGE_ALIASES = {
 
 // 白名单，只保留算法竞赛常用的语言，避免一些奇奇怪怪的匹配
 
-const COMPETITIVE_LANGUAGES = new Set([
+const COMPETITIVE_LANGUAGES = [
     'cpp','python','java','rust','csharp',
     'ruby','kotlin','haskell','go','javascript',
-    'typescript','swift','swift','d','php','julia'
-]);
+    'typescript','swift','d','php','julia'
+];
 
 /**
  * 尝试从 DOM 中获取代码语言
@@ -5256,18 +5256,8 @@ function normalizeLang(raw) {
  * @returns 可能的代码语言，准确度取决于 HLJS
  */
 function whitelistFallback(code) {
-    const result = hljs.highlightAuto(code);
-
-    // 按 relevance 降序，找第一个在白名单里的语言
-    const languages = result.language
-        ? [result.language, ...(result.secondBest ? [result.secondBest.language] : [])]
-        : [];
-
-    for (const lang of languages) {
-        if (COMPETITIVE_LANGUAGES.has(lang)) return lang;
-    }
-
-    return 'plaintext';
+    const result = hljs.highlightAuto(code,COMPETITIVE_LANGUAGES);
+    return result.language||'plaintext';
 }
 
 

--- a/script/dev/codeforces-better.user.js
+++ b/script/dev/codeforces-better.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         Codeforces Better!
 // @namespace    https://greasyfork.org/users/747162
-// @version      1.85.1
+// @version      1.85.2
 // @author       北极小狐
 // @match        *://*.codeforces.com/*
 // @match        *://*.codeforc.es/*

--- a/script/dev/codeforces-better.user.js
+++ b/script/dev/codeforces-better.user.js
@@ -2321,7 +2321,7 @@ async function beautifyPreBlocksWithMonaco() {
     if (pre.hasClass("source-code-for-copy")) return; // 跳过复制块
     const code = OJB_getCodeFromPre(pre.get(0));
     if (!code) return;
-    const language = OJB_codeLangDetect(code,preElement);
+    const language = OJB_codeLangDetect(code, preElement);
 
     // 创建一个用于 Monaco 编辑器的容器
     const container = $("<div></div>");
@@ -5180,26 +5180,26 @@ function OJB_getCodeFromPre(element) {
 // 映射表，考虑一些作者会写出奇奇怪怪的语言名，先做一个映射；有些是平台自动生成的，有些单纯是防止作者写奇奇怪怪的名称
 
 const LANGUAGE_ALIASES = {
-    'py': 'python', 'python3': 'python', 'py3': 'python',
-    'c++': 'cpp', 'c_cpp': 'cpp', 'cc': 'cpp', 'cxx': 'cpp', 'cplusplus': 'cpp',
-    'js': 'javascript', 'node': 'javascript',
-    'cs': 'csharp', 'c#': 'csharp',
-    'golang': 'go',
-    'rs': 'rust', 
-    'rb': 'ruby', 
-    'kt': 'kotlin',
-    'hs': 'haskell',
-    'jl': 'julia',
-    'ts': 'typescript',
-    'md':'markdown'
+  "py": "python", "python3": "python", "py3": "python",
+  "c++": "cpp", "c_cpp": "cpp", "cc": "cpp", "cxx": "cpp", "cplusplus": "cpp",
+  "js": "javascript", "node": "javascript",
+  "cs": "csharp", "c#": "csharp",
+  "golang": "go",
+  "rs": "rust",
+  "rb": "ruby",
+  "kt": "kotlin",
+  "hs": "haskell",
+  "jl": "julia",
+  "ts": "typescript",
+  "md": "markdown",
 };
 
 // 白名单，只保留算法竞赛常用的语言，避免一些奇奇怪怪的匹配
 
 const COMPETITIVE_LANGUAGES = [
-    'cpp','python','java','rust','csharp',
-    'ruby','kotlin','haskell','go','javascript',
-    'typescript','swift','d','php','julia'
+  "cpp", "python", "java", "rust", "csharp",
+  "ruby", "kotlin", "haskell", "go", "javascript",
+  "typescript", "swift", "d", "php", "julia",
 ];
 
 /**
@@ -5208,35 +5208,26 @@ const COMPETITIVE_LANGUAGES = [
  * @returns {string|null} 从 DOM 中获取的语言
  */
 function detectLanguageFromDOM(element) {
-    if (!element) return null;
-    /*Atcoder 的逻辑，codeforces 不用管
-    // 1. data-ace-mode（AtCoder Submission）
-    // Atcoder submission 中 通过 <pre> 上的 data-ace-mode 来存语言类型
-    const ace = element.dataset?.aceMode;
-    if (ace) {
-        const result = normalizeLang(ace);
-        if (result) return result;
-    }
-    */
-    // 2. class 里的 language-xxx 或 lang-xxx
-    // 与 HighlightJS 保持一致或类似的做法，存在一个 lang(uage)- 表示语言
-    const cls = element.className || '';
-    const match = cls.match(/(?:^|\s)(?:lang(?:uage)?-)(\S+)/i);
-    if (match) {
-        const result = normalizeLang(match[1]);
-        if (result) return result;
-    }
-    
-    // 3. 从 <pre><code> 里获取的 language-xxx 或 lang-xxx
+  if (!element) return null;
 
-    const ccls = element.querySelector('code').className || '';
-    const cmatch = ccls.match(/(?:^|\s)(?:lang(?:uage)?-)(\S+)/i);
-    if (cmatch) {
-        const result = normalizeLang(cmatch[1]);
-        if (result) return result;
-    }
+  // 1. class 里的 language-xxx 或 lang-xxx
+  // 与 HighlightJS 保持一致或类似的做法，存在一个 lang(uage)- 表示语言
+  const cls = element.className || "";
+  const match = cls.match(/(?:^|\s)(?:lang(?:uage)?-)(\S+)/i);
+  if (match) {
+    const result = normalizeLang(match[1]);
+    if (result) return result;
+  }
 
-    return null;
+  // 2. 从 <pre><code> 里获取的 language-xxx 或 lang-xxx
+  const ccls = element.querySelector("code")?.className || "";
+  const cmatch = ccls.match(/(?:^|\s)(?:lang(?:uage)?-)(\S+)/i);
+  if (cmatch) {
+    const result = normalizeLang(cmatch[1]);
+    if (result) return result;
+  }
+
+  return null;
 }
 
 /**
@@ -5245,9 +5236,10 @@ function detectLanguageFromDOM(element) {
  * @returns 格式化后，Monaco Editor 认识的语言名
  */
 function normalizeLang(raw) {
-    const normalized = raw.trim().toLowerCase();
-    if(monaco.languages.getLanguages().map(l => l.id).includes(normalized)) return normalized;
-    return LANGUAGE_ALIASES[normalized] || null;
+  if (!raw) return null;
+  const normalized = raw.trim().toLowerCase();
+  if (monaco.languages.getLanguages().map((l) => l.id).includes(normalized)) return normalized;
+  return LANGUAGE_ALIASES[normalized] || null;
 }
 
 /**
@@ -5256,8 +5248,8 @@ function normalizeLang(raw) {
  * @returns 可能的代码语言，准确度取决于 HLJS
  */
 function whitelistFallback(code) {
-    const result = hljs.highlightAuto(code,COMPETITIVE_LANGUAGES);
-    return result.language||'plaintext';
+  const result = hljs.highlightAuto(code, COMPETITIVE_LANGUAGES);
+  return result.language || "plaintext";
 }
 
 
@@ -5268,12 +5260,12 @@ function whitelistFallback(code) {
  * @returns {string} 可能的语言
  */
 function OJB_codeLangDetect(code, element) {
-    // 第一层：DOM 优先
-    const fromDOM = detectLanguageFromDOM(element);
-    if (fromDOM) return fromDOM;
+  // 第一层：DOM 优先
+  const fromDOM = detectLanguageFromDOM(element);
+  if (fromDOM) return fromDOM;
 
-    // 第二层：白名单兜底
-    return  whitelistFallback(code);
+  // 第二层：白名单兜底
+  return whitelistFallback(code);
 }
 
 /**

--- a/script/dev/codeforces-better.user.js
+++ b/script/dev/codeforces-better.user.js
@@ -5199,7 +5199,7 @@ const LANGUAGE_ALIASES = {
 const COMPETITIVE_LANGUAGES = new Set([
     'cpp','python','java','rust','csharp',
     'ruby','kotlin','haskell','go','javascript',
-    'typescript','swift','swift','d','php','julia'
+    'typescript','swift','d','php','julia'
 ]);
 
 /**

--- a/script/dev/codeforces-better.user.js
+++ b/script/dev/codeforces-better.user.js
@@ -2321,7 +2321,7 @@ async function beautifyPreBlocksWithMonaco() {
     if (pre.hasClass("source-code-for-copy")) return; // 跳过复制块
     const code = OJB_getCodeFromPre(pre.get(0));
     if (!code) return;
-    const language = OJB_codeLangDetect(code);
+    const language = OJB_codeLangDetect(code,preElement);
 
     // 创建一个用于 Monaco 编辑器的容器
     const container = $("<div></div>");
@@ -5176,15 +5176,114 @@ function OJB_getCodeFromPre(element) {
   result = result.replace(/\u00A0/g, ""); // 过滤文本中的U+00a0字符（由&nbsp;造成的）
   return result;
 }
+// =================处理代码块语言===============
+// 映射表，考虑一些作者会写出奇奇怪怪的语言名，先做一个映射；有些是平台自动生成的，有些单纯是防止作者写奇奇怪怪的名称
+
+const LANGUAGE_ALIASES = {
+    'py': 'python', 'python3': 'python', 'py3': 'python',
+    'c++': 'cpp', 'c_cpp': 'cpp', 'cc': 'cpp', 'cxx': 'cpp', 'cplusplus': 'cpp',
+    'js': 'javascript', 'node': 'javascript',
+    'cs': 'csharp', 'c#': 'csharp',
+    'golang': 'go',
+    'rs': 'rust', 
+    'rb': 'ruby', 
+    'kt': 'kotlin',
+    'hs': 'haskell',
+    'jl': 'julia',
+    'ts': 'typescript',
+    'md':'markdown'
+};
+
+// 白名单，只保留算法竞赛常用的语言，避免一些奇奇怪怪的匹配
+
+const COMPETITIVE_LANGUAGES = new Set([
+    'cpp','python','java','rust','csharp',
+    'ruby','kotlin','haskell','go','javascript',
+    'typescript','swift','swift','d','php','julia'
+]);
+
+/**
+ * 尝试从 DOM 中获取代码语言
+ * @param {htmlElement | null} element 所在的 <pre> 标签
+ * @returns {string|null} 从 DOM 中获取的语言
+ */
+function detectLanguageFromDOM(element) {
+    if (!element) return null;
+    /*Atcoder 的逻辑，codeforces 不用管
+    // 1. data-ace-mode（AtCoder Submission）
+    // Atcoder submission 中 通过 <pre> 上的 data-ace-mode 来存语言类型
+    const ace = element.dataset?.aceMode;
+    if (ace) {
+        const result = normalizeLang(ace);
+        if (result) return result;
+    }
+    */
+    // 2. class 里的 language-xxx 或 lang-xxx
+    // 与 HighlightJS 保持一致或类似的做法，存在一个 lang(uage)- 表示语言
+    const cls = element.className || '';
+    const match = cls.match(/(?:^|\s)(?:lang(?:uage)?-)(\S+)/i);
+    if (match) {
+        const result = normalizeLang(match[1]);
+        if (result) return result;
+    }
+    
+    // 3. 从 <pre><code> 里获取的 language-xxx 或 lang-xxx
+
+    const ccls = element.querySelector('code').className || '';
+    const cmatch = ccls.match(/(?:^|\s)(?:lang(?:uage)?-)(\S+)/i);
+    if (cmatch) {
+        const result = normalizeLang(cmatch[1]);
+        if (result) return result;
+    }
+
+    return null;
+}
+
+/**
+ * 格式化语言名
+ * @param {string | null} raw 未加处理的，直接从 DOM 中获取的语言名
+ * @returns 格式化后，Monaco Editor 认识的语言名
+ */
+function normalizeLang(raw) {
+    const normalized = raw.trim().toLowerCase();
+    if(monaco.languages.getLanguages().map(l => l.id).includes(normalized)) return normalized;
+    return LANGUAGE_ALIASES[normalized] || null;
+}
+
+/**
+ *  第二层：检测白名单中的语言，避免 HLJS 匹配一些奇怪的语言
+ * @param {string} code 需要检查的代码
+ * @returns 可能的代码语言，准确度取决于 HLJS
+ */
+function whitelistFallback(code) {
+    const result = hljs.highlightAuto(code);
+
+    // 按 relevance 降序，找第一个在白名单里的语言
+    const languages = result.language
+        ? [result.language, ...(result.secondBest ? [result.secondBest.language] : [])]
+        : [];
+
+    for (const lang of languages) {
+        if (COMPETITIVE_LANGUAGES.has(lang)) return lang;
+    }
+
+    return 'plaintext';
+}
+
 
 /**
  * 判断代码的语言
  * @param {string} code 代码文本
+ * @param {HTMLElement | null} element 代码所在的 <pre> 标签
  * @returns {string} 可能的语言
  */
-function OJB_codeLangDetect(code) {
-  result = hljs.highlightAuto(code);
-  return result.language;
+function OJB_codeLangDetect(code, element) {
+    // 第一层：DOM 优先
+    const fromDOM = detectLanguageFromDOM(element);
+    if (fromDOM) return fromDOM;
+
+    // 第二层：白名单兜底
+    return  whitelistFallback(code);
 }
 
 /**


### PR DESCRIPTION
主要为了修复 issue #390 ，该问题在 Atcoder Better! 也存在，CF 和 AT 都修复了。

方案：

- 增加了从 DOM 获取语言信息的过程（对于提交记录这步一定可以确认）；
- 此外，如果不能从 DOM 获取语言信息，从更窄的“算法竞赛常用语言白名单”中匹配；
- 其它的降级为 `plaintext`

这么做的原因：

- 根据现有案例，主要存在 C++ 被错误识别成 perl，python 被识别成 SCSS/CSS 等误识别，而后者在算法竞赛中出现概率极低；
- 抽样调查了 ABC 461 的提交记录，提取至少二十次提交的语言，做成白名单；（这步是人工做的，可能有遗漏，但主流的语言都在，未来维护只需要简单添加就行）
- 我认为显示为 `plaintext` 也比显示错误好，所以可能会有少量的小众语言会被降级为 `plaintext`；
- 据观察，目前没有发现在非提交记录中有小众语言的情况，暂时没发现错误

附白名单：

```javascript
const COMPETITIVE_LANGUAGES = new Set([
    'cpp','python','java','rust','csharp',
    'ruby','kotlin','haskell','go','javascript',
    'typescript','swift','d','php','julia'
]);
```