### PR TITLE
关于ai翻译的一些修复

### DIFF
--- a/script/dev/atcoder-better.user.js
+++ b/script/dev/atcoder-better.user.js
@@ -14357,9 +14357,12 @@ Rules:
 ${hasReplaceOriginalMarker ? "6. Keep all [[OJBLOCK_xxxx]] and [[/OJBLOCK_xxxx]] markers unchanged and in the same order" : ""}
 
 Text to translate:
-"
+"`;
+        if (!OJBetter.chatgpt.asSystemPrompt) {
+            prompt += `
 ${raw}
 "`;
+        }
     };
 
     const url = OJBetter.chatgpt.config.proxy || proxyDefault;

--- a/script/dev/atcoder-better.user.js
+++ b/script/dev/atcoder-better.user.js
@@ -5496,6 +5496,9 @@ class Validator {
                 case 'keyValuePairs':
                     isValid = Validator.keyValuePairs(fieldValue);
                     break;
+                case 'keyValuePairsOrJson':
+                    isValid = Validator.keyValuePairsOrJson(fieldValue);
+                    break;
                 case 'dotSeparatedPath':
                     isValid = Validator.validateDotSeparatedPath(fieldValue);
                     break;
@@ -5544,6 +5547,23 @@ class Validator {
         // 允许值中包含空格和冒号
         const regex = /^[a-zA-Z0-9_-]+\s*:\s*.+$/;
         return keyValuePairs.every(pair => regex.test(pair));
+    }
+
+    /**
+     * 键值对或顶级JSON对象校验
+     * @param {string} value
+     * @returns {boolean}
+     */
+    static keyValuePairsOrJson(value) {
+        if (typeof value !== "string" || value.trim() === "") return true;
+        const trimmed = value.trim();
+        if (/^[\[{]/.test(trimmed)) {
+            try { JSON.parse(trimmed); return true; }
+            catch { return false; }
+        }
+        const pairs = value.split('\n');
+        const regex = /^[a-zA-Z0-9_-]+\s*:\s*.+$/;
+        return pairs.every(pair => regex.test(pair));
     }
 
 
@@ -7095,11 +7115,11 @@ async function initSettingsPanel() {
             '#deepl_key': createStructure('text', 'key', false),
             '#deepl_proxy': createStructure('text', 'proxy', false),
             '#deepl_header': createStructure('text', '_header', false, 'keyValuePairs'),
-            '#deepl_data': createStructure('text', '_data', false, 'keyValuePairs'),
+            '#deepl_data': createStructure('text', '_data', false, 'keyValuePairsOrJson'),
             '#deepl_quota_url': createStructure('text', 'quota_url', false),
             '#deepl_quota_method': createStructure('text', 'quota_method', false),
             '#deepl_quota_header': createStructure('text', 'quota_header', false, 'keyValuePairs'),
-            '#deepl_quota_data': createStructure('text', 'quota_data', false, 'keyValuePairs'),
+            '#deepl_quota_data': createStructure('text', 'quota_data', false, 'keyValuePairsOrJson'),
             '#deepl_quota_surplus': createStructure('text', 'quota_surplus', false, 'dotSeparatedPath'),
         };
         let tempConfig_deepl = GM_getValue('deepl_config'); // 获取配置信息
@@ -7114,10 +7134,10 @@ async function initSettingsPanel() {
             '#chatgpt_key': createStructure('text', 'key', true),
             '#chatgpt_proxy': createStructure('text', 'proxy', false),
             '#chatgpt_header': createStructure('text', '_header', false, 'keyValuePairs'),
-            '#chatgpt_data': createStructure('text', '_data', false, 'keyValuePairs'),
+            '#chatgpt_data': createStructure('text', '_data', false, 'keyValuePairsOrJson'),
             '#chatgpt_quota_url': createStructure('text', 'quota_url', false),
             '#chatgpt_quota_header': createStructure('text', 'quota_header', false, 'keyValuePairs'),
-            '#chatgpt_quota_data': createStructure('text', 'quota_data', false, 'keyValuePairs'),
+            '#chatgpt_quota_data': createStructure('text', 'quota_data', false, 'keyValuePairsOrJson'),
             '#chatgpt_quota_surplus': createStructure('text', 'quota_surplus', false, 'dotSeparatedPath'),
             '#chatgpt_quota_method': createStructure('text', 'quota_method', false),
         };

--- a/script/dev/atcoder-better.user.js
+++ b/script/dev/atcoder-better.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         Atcoder Better!
 // @namespace    https://greasyfork.org/users/747162
-// @version      1.23.5
+// @version      1.23.6
 // @description  一个适用于 AtCoder 的 Tampermonkey 脚本，增强功能与界面。
 // @author       北极小狐
 // @match        *://atcoder.jp/*

--- a/script/dev/atcoder-better.user.js
+++ b/script/dev/atcoder-better.user.js
@@ -14313,11 +14313,6 @@ async function translate_caiyun(raw) {
     return await BaseTranslate(options, res => JSON.parse(res).target.map(decoder).join('\n'))
 }
 
-/**
- * ChatGPT
- * @param {string} raw 原文
- * @returns {Promise<TransRawData>} 翻译结果对象
- */
 function isOpenAIResponsesEndpoint(url) {
     return /\/v1\/responses(?:$|[/?#])/.test(url);
 }
@@ -14431,6 +14426,11 @@ ${raw}
     };
 }
 
+/**
+ * ChatGPT
+ * @param {string} raw 原文
+ * @returns {Promise<TransRawData>} 翻译结果对象
+ */
 async function translate_openai(raw) {
     const request = getOpenAITranslationRequest(raw);
     const options = {

--- a/script/dev/codeforces-better.user.js
+++ b/script/dev/codeforces-better.user.js
@@ -17520,11 +17520,6 @@ async function translate_caiyun(raw) {
   );
 }
 
-/**
- * ChatGPT
- * @param {string} raw 原文
- * @returns {Promise<TransRawData>} 翻译结果对象
- */
 function isOpenAIResponsesEndpoint(url) {
   return /\/v1\/responses(?:$|[/?#])/.test(url);
 }
@@ -17643,6 +17638,11 @@ ${raw}
   };
 }
 
+/**
+ * ChatGPT
+ * @param {string} raw 原文
+ * @returns {Promise<TransRawData>} 翻译结果对象
+ */
 async function translate_openai(raw) {
   const request = getOpenAITranslationRequest(raw);
   const options = {

--- a/script/dev/codeforces-better.user.js
+++ b/script/dev/codeforces-better.user.js
@@ -6407,6 +6407,9 @@ class Validator {
         case "keyValuePairs":
           isValid = Validator.keyValuePairs(fieldValue);
           break;
+        case "keyValuePairsOrJson":
+          isValid = Validator.keyValuePairsOrJson(fieldValue);
+          break;
         case "dotSeparatedPath":
           isValid = Validator.validateDotSeparatedPath(fieldValue);
           break;
@@ -6457,6 +6460,23 @@ class Validator {
     // 允许值中包含空格和冒号
     const regex = /^[a-zA-Z0-9_-]+\s*:\s*.+$/;
     return keyValuePairs.every((pair) => regex.test(pair));
+  }
+
+  /**
+   * 键值对或顶级JSON对象校验
+   * @param {string} value
+   * @returns {boolean}
+   */
+  static keyValuePairsOrJson(value) {
+    if (typeof value !== "string" || value.trim() === "") return true;
+    const trimmed = value.trim();
+    if (/^[\[{]/.test(trimmed)) {
+      try { JSON.parse(trimmed); return true; }
+      catch { return false; }
+    }
+    const pairs = value.split("\n");
+    const regex = /^[a-zA-Z0-9_-]+\s*:\s*.+$/;
+    return pairs.every((pair) => regex.test(pair));
   }
 
   /**
@@ -8091,7 +8111,7 @@ async function initSettingsPanel() {
         false,
         "keyValuePairs"
       ),
-      "#deepl_data": createStructure("text", "_data", false, "keyValuePairs"),
+      "#deepl_data": createStructure("text", "_data", false, "keyValuePairsOrJson"),
       "#deepl_quota_url": createStructure("text", "quota_url", false),
       "#deepl_quota_method": createStructure("text", "quota_method", false),
       "#deepl_quota_header": createStructure(
@@ -8104,7 +8124,7 @@ async function initSettingsPanel() {
         "text",
         "quota_data",
         false,
-        "keyValuePairs"
+        "keyValuePairsOrJson"
       ),
       "#deepl_quota_surplus": createStructure(
         "text",
@@ -8136,7 +8156,7 @@ async function initSettingsPanel() {
         false,
         "keyValuePairs"
       ),
-      "#chatgpt_data": createStructure("text", "_data", false, "keyValuePairs"),
+      "#chatgpt_data": createStructure("text", "_data", false, "keyValuePairsOrJson"),
       "#chatgpt_quota_url": createStructure("text", "quota_url", false),
       "#chatgpt_quota_header": createStructure(
         "text",
@@ -8148,7 +8168,7 @@ async function initSettingsPanel() {
         "text",
         "quota_data",
         false,
-        "keyValuePairs"
+        "keyValuePairsOrJson"
       ),
       "#chatgpt_quota_surplus": createStructure(
         "text",

--- a/script/dev/codeforces-better.user.js
+++ b/script/dev/codeforces-better.user.js
@@ -17569,9 +17569,12 @@ Rules:
 ${hasReplaceOriginalMarker ? "6. Keep all [[OJBLOCK_xxxx]] and [[/OJBLOCK_xxxx]] markers unchanged and in the same order" : ""}
 
 Text to translate:
-"
+"`;
+    if (!OJBetter.chatgpt.asSystemPrompt) {
+      prompt += `
 ${raw}
 "`;
+    }
   }
 
   const url = OJBetter.chatgpt.config.proxy || proxyDefault;

--- a/script/dev/codeforces-better.user.js
+++ b/script/dev/codeforces-better.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         Codeforces Better!
 // @namespace    https://greasyfork.org/users/747162
-// @version      1.85.5
+// @version      1.85.6
 // @author       北极小狐
 // @match        *://*.codeforces.com/*
 // @match        *://*.codeforc.es/*

--- a/script/versions.json
+++ b/script/versions.json
@@ -4,11 +4,11 @@
         "release": "3.29.0"
     },
     "atcoder-better": {
-        "dev": "1.23.5",
+        "dev": "1.23.6",
         "release": "1.20.0"
     },
     "codeforces-better": {
-        "dev": "1.85.5",
+        "dev": "1.85.6",
         "release": "1.80.0"
     },
     "nowcoder-better": {


### PR DESCRIPTION
修复以下问题：
1.ai翻译接口自定义data支持对象类型，但是由于配置界面的参数校验未考虑这种情况，实际上无法保存配置
2.ai翻译若使用默认提示词且开启系统提示词，待翻译文本错误的追加到系统提示词中
3.提交bc41de2f将一些原先正确的JSDoc注释移动到了错误的位置