### PR TITLE
fix: 修复分屏等窄屏下设置按钮挤压换行、遮挡二级导航的问题

### DIFF
--- a/script/dev/atcoder-better.user.js
+++ b/script/dev/atcoder-better.user.js
@@ -6973,6 +6973,18 @@ async function initSettingsPanel() {
         $(location)[method](`<button class='ojb_btn OJBetter_setting'>
         ${OJBetter.state.name} ${i18next.t('settings', { ns: 'common' })}</button>`);
     }
+    function insertOJBetterSettingButton(location, method) {
+        // 将原本的 <button> 改为 Bootstrap 规范的 <li><a> 结构
+        // 增加了一个齿轮图标，并用 span 包裹文字以便 CSS 控制
+        $(location)[method](`
+        <li>
+            <a href="javascript:void(0);" class="OJBetter_setting" style="cursor: pointer;">
+            <span class="glyphicon glyphicon-cog" aria-hidden="true"></span>
+            <span class="ojb-setting-text"> ${OJBetter.state.name} ${i18next.t("settings", { ns: "common" })}</span>
+            </a>
+        </li>
+        `);
+    }
 
     /**
      * ============================================

--- a/script/dev/atcoder-better.user.js
+++ b/script/dev/atcoder-better.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         Atcoder Better!
 // @namespace    https://greasyfork.org/users/747162
-// @version      1.23.7
+// @version      1.23.8
 // @description  一个适用于 AtCoder 的 Tampermonkey 脚本，增强功能与界面。
 // @author       北极小狐
 // @match        *://atcoder.jp/*
@@ -6969,10 +6969,6 @@ async function initSettingsPanel() {
      * @param {string} location 位置选择器
      * @param {string} method 插入方法
      */
-    function insertOJBetterSettingButton(location, method) {
-        $(location)[method](`<button class='ojb_btn OJBetter_setting'>
-        ${OJBetter.state.name} ${i18next.t('settings', { ns: 'common' })}</button>`);
-    }
     function insertOJBetterSettingButton(location, method) {
         // 将原本的 <button> 改为 Bootstrap 规范的 <li><a> 结构
         // 增加了一个齿轮图标，并用 span 包裹文字以便 CSS 控制


### PR DESCRIPTION
fixes #382

此操作更改了设置按钮样式，使其与atcoder样式和Bootstrap 3响应相匹配

<img width="165" height="73" alt="image" src="https://github.com/user-attachments/assets/a623d34c-1992-4d4a-8a6a-783f1645439e" /></br>

<img width="180" height="38" alt="image" src="https://github.com/user-attachments/assets/1e226c12-37cd-4fc0-9122-79c1e1d4f8db" /></br>(日语页面)


