### PR TITLE
fix(Codeforces): 支持 G++23 Monaco 语法高亮

### DIFF
--- a/script/dev/codeforces-better.user.js
+++ b/script/dev/codeforces-better.user.js
@@ -15588,6 +15588,7 @@ const value_monacoLanguageMap = {
   83: "kotlin",
   87: "java",
   89: "cpp",
+  91: "cpp",
 };
 
 /**


### PR DESCRIPTION
将 Codeforces 编译器 ID 91 映射为 Monaco 的cpp语言模式，使得题目页 Monaco 编辑器支持 GNU G++23 的语法高亮。