### PR TITLE
fix(Codeforces): 修复暗色模式下图片公式显示

### DIFF
--- a/script/dev/codeforces-better.user.js
+++ b/script/dev/codeforces-better.user.js
@@ -2194,6 +2194,11 @@ const handleColorSchemeChange = (event) => {
         html[data-theme=dark] img, html[data-theme=dark] #facebox .popup a{
             opacity: .75;
         }
+        /* 图片公式反色 */
+        html[data-theme=dark] img.tex-formula {
+            opacity: 1;
+            filter: invert(1);
+        }
         /* 反转 */
         html[data-theme=dark] .SumoSelect>.CaptionCont>label>i, html[data-theme=dark] .delete-resource-link,
         html[data-theme=dark] #program-source-text, html[data-theme=dark] .spoiler-content pre,


### PR DESCRIPTION
## 原有问题

cf better 设置为暗色模式的时候，cf 旧版的图片公式 `.tex-formula` 仍然是黑色字体，不能正确反色，造成可见度较低的问题。

## 修改

在暗色模式下为 `img.tex-formula` 添加 `invert(1)` 滤镜， `opacity` 设定为 `1`。

Before:

<img width="200" alt="image" src="https://github.com/user-attachments/assets/dd281154-e839-4269-93c7-9c27e05ffea4" />

After:

<img width="200"  alt="image" src="https://github.com/user-attachments/assets/752b1ed8-7122-41a1-81eb-6cf653f09315" />
