### PR TITLE
修复了html2md对于部分Codeforces中class支持不全的bug

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,5 +21,7 @@ tools/unit/test/replaceOriginal/*
 !tools/unit/test/edge/index.node.js
 !tools/unit/test/codeforcesMathJax/
 !tools/unit/test/codeforcesMathJax/index.node.js
+!tools/unit/test/codeforcesHtml2Markdown/
+!tools/unit/test/codeforcesHtml2Markdown/index.node.js
 !tools/unit/test/contextMenu/
 !tools/unit/test/contextMenu/index.test.js

--- a/script/dev/codeforces-better.user.js
+++ b/script/dev/codeforces-better.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         Codeforces Better!
 // @namespace    https://greasyfork.org/users/747162
-// @version      1.87.9
+// @version      1.87.10
 // @author       北极小狐
 // @match        *://*.codeforces.com/*
 // @match        *://*.codeforc.es/*
@@ -9196,8 +9196,8 @@ async function initHTML2MarkDown() {
     },
   });
 
-  // texFontStyle
-  OJBetter.common.turndownService.addRule("texFontStyle", {
+  // tex-font-style-*
+  OJBetter.common.turndownService.addRule("tex-bf", {
     filter: function (node) {
       return (
         node.nodeName === "SPAN" && node.classList.contains("tex-font-style-bf")
@@ -9207,9 +9207,61 @@ async function initHTML2MarkDown() {
       return "**" + content + "**";
     },
   });
+  OJBetter.common.turndownService.addRule("tex-it", {
+    filter: function (node) {
+      return (
+        node.nodeName === "SPAN" && node.classList.contains("tex-font-style-it")
+      );
+    },
+    replacement: function (content) {
+      return "*" + content + "*";
+    },
+  });
+  OJBetter.common.turndownService.addRule("tex-sl", {
+    filter: function (node) {
+      return (
+        node.nodeName === "SPAN" && node.classList.contains("tex-font-style-sl")
+      );
+    },
+    replacement: function (content) {
+      return "*" + content + "*";
+    },
+  });
+  OJBetter.common.turndownService.addRule("tex-tt", {
+    filter: function (node) {
+      return (
+        node.nodeName === "SPAN" && node.classList.contains("tex-font-style-tt")
+      );
+    },
+    replacement: function (content) {
+      return "`" + content + "`";
+    },
+  });
+  OJBetter.common.turndownService.addRule("tex-striked", {
+    filter: function (node) {
+      return (
+        node.nodeName === "SPAN" && node.classList.contains("tex-font-style-striked")
+      );
+    },
+    replacement: function (content) {
+      return "~~" + content + "~~";
+    },
+  });
+  
+  // text-verb
+  OJBetter.common.turndownService.addRule("text-verb", {
+    filter: function (node) {
+      return (
+        node.nodeName === "SPAN" && node.classList.contains("text-verb")
+      );
+    },
+    replacement: function (content) {
+      return content.length === 0 ? "" : "`" + content + "`";
+    },
+  });
 
-  // sectionTitle
-  OJBetter.common.turndownService.addRule("sectionTitle", {
+  // section-title
+  OJBetter.common.turndownService.addRule("section-title", {
     filter: function (node) {
       return (
         node.nodeName === "DIV" && node.classList.contains("section-title")

--- a/script/dev/codeforces-better.user.js
+++ b/script/dev/codeforces-better.user.js
@@ -9111,6 +9111,18 @@ async function initSettingsPanel() {
   });
 }
 
+function OJB_createMarkdownCodeSpan(value) {
+  const content = String(value ?? "").replace(/\r?\n|\r/g, " ");
+  if (!content) return "";
+
+  const backtickRuns = content.match(/`+/g) || [];
+  let delimiter = "`";
+  while (backtickRuns.includes(delimiter)) delimiter += "`";
+
+  const padding = /^`|^ .*?[^ ].* $|`$/.test(content) ? " " : "";
+  return delimiter + padding + content + padding + delimiter;
+}
+
 /**
  * 初始化html2markdown转换器
  */
@@ -9233,8 +9245,8 @@ async function initHTML2MarkDown() {
         node.nodeName === "SPAN" && node.classList.contains("tex-font-style-tt")
       );
     },
-    replacement: function (content) {
-      return "`" + content + "`";
+    replacement: function (_content, node) {
+      return OJB_createMarkdownCodeSpan(node.textContent);
     },
   });
   OJBetter.common.turndownService.addRule("tex-striked", {
@@ -9247,7 +9259,7 @@ async function initHTML2MarkDown() {
       return "~~" + content + "~~";
     },
   });
-  
+
   // text-verb
   OJBetter.common.turndownService.addRule("text-verb", {
     filter: function (node) {
@@ -9255,8 +9267,8 @@ async function initHTML2MarkDown() {
         node.nodeName === "SPAN" && node.classList.contains("text-verb")
       );
     },
-    replacement: function (content) {
-      return content.length === 0 ? "" : "`" + content + "`";
+    replacement: function (_content, node) {
+      return OJB_createMarkdownCodeSpan(node.textContent);
     },
   });
 

--- a/script/versions.json
+++ b/script/versions.json
@@ -8,7 +8,7 @@
         "release": "1.25.1"
     },
     "codeforces-better": {
-        "dev": "1.87.9",
+        "dev": "1.87.10",
         "release": "1.87.1"
     },
     "nowcoder-better": {

--- a/tools/unit/package.json
+++ b/tools/unit/package.json
@@ -5,6 +5,7 @@
         "test:openai": "node --test test/openai/index.node.js",
         "test:edge": "node --test test/edge/index.node.js",
         "test:codeforces-mathjax": "node --test test/codeforcesMathJax/index.node.js",
+        "test:codeforces-html2markdown": "node --test test/codeforcesHtml2Markdown/index.node.js",
         "test:update-version": "node --test ../../.github/scripts/update-version.test.js"
     },
     "devDependencies": {

--- a/tools/unit/test/codeforcesHtml2Markdown/index.node.js
+++ b/tools/unit/test/codeforcesHtml2Markdown/index.node.js
@@ -1,0 +1,63 @@
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const test = require('node:test');
+const vm = require('node:vm');
+
+const SCRIPT_PATH = path.resolve(
+    __dirname,
+    '../../../../script/dev/codeforces-better.user.js'
+);
+const SOURCE = fs.readFileSync(SCRIPT_PATH, 'utf8').replace(/\r\n/g, '\n');
+
+function loadCodeSpanHelper() {
+    const start = SOURCE.indexOf('function OJB_createMarkdownCodeSpan(');
+    const end = SOURCE.indexOf(
+        '\n\n/**\n * 初始化html2markdown转换器',
+        start
+    );
+    assert.notEqual(start, -1, 'missing production code-span helper');
+    assert.ok(end > start, 'missing production code-span helper end');
+
+    const context = vm.createContext({});
+    vm.runInContext(
+        `${SOURCE.slice(start, end)}\n` +
+        'globalThis.__createMarkdownCodeSpan = OJB_createMarkdownCodeSpan;',
+        context,
+        { filename: SCRIPT_PATH }
+    );
+    return context.__createMarkdownCodeSpan;
+}
+
+function getRuleSource(name) {
+    const start = SOURCE.indexOf(`turndownService.addRule("${name}", {`);
+    const end = SOURCE.indexOf('\n  });', start);
+    assert.notEqual(start, -1, `missing ${name} rule`);
+    assert.ok(end > start, `missing ${name} rule end`);
+    return SOURCE.slice(start, end + '\n  });'.length);
+}
+
+test('creates Markdown code spans without escaping literal code characters', () => {
+    const createCodeSpan = loadCodeSpanHelper();
+
+    for (const [value, expected] of [
+        ['', ''],
+        ['A 3 1', '`A 3 1`'],
+        ['a_b[x]\\y', '`a_b[x]\\y`'],
+        ['use `x`', '`` use `x` ``'],
+        ['a ` b', '``a ` b``'],
+        ['first\nsecond', '`first second`']
+    ]) {
+        assert.equal(createCodeSpan(value), expected);
+    }
+});
+
+test('reads raw DOM text for both Codeforces code-style rules', () => {
+    for (const name of ['tex-tt', 'text-verb']) {
+        const rule = getRuleSource(name);
+        assert.match(
+            rule,
+            /replacement: function \(_content, node\) \{\s*return OJB_createMarkdownCodeSpan\(node\.textContent\);/
+        );
+    }
+});


### PR DESCRIPTION
Codeforces大概是不按套路出牌的，比如加粗人家不用`strong`，人家用`class=tex-font-style-bf`……

所以我去摸索了一下Codeforces的[css](https://codeforces.com/codeforces.org/s/21059/css/problem-statement.css)（from F12），添加了对于斜体（2个）、代码块（2个）、删除线的支持。

另外改了一下附近注释和命名格式，有些是`sectionTitle`这样的，有些又是`inline-math`这样的，统一为后者。

具体示例的话，可以看[1534D](https://codeforces.com/contest/1534/problem/D)（from 今天的Duel每日一题）和[2222E](https://codeforces.com/contest/2222/problem/E)（from #416 ）：
- 前者的`*This is an interactive problem*.`（对应`-it`）和`~~make the game unfair~~`（对应`-striked`）。
- 后者下方表格里的`A 3 1`等（对应`text-verb`）。
- 以及两者都有的`Idleness limit exceeded`（对应`-tt`）。
- 源码里说斜体还有`-sl`，但目前没见过，先写上。