### PR TITLE
添加对于AHC的生成式AI规则翻译&修改nav翻译范围

### DIFF
--- a/resources/subs/atcoder-better.json
+++ b/resources/subs/atcoder-better.json
@@ -157,7 +157,7 @@
         },
         "traverseTextNodes3": {
             "class": [
-                ".nav"
+                ".nav.nav-tabs"
             ],
             "description": "",
             "isStrict": true,
@@ -800,7 +800,8 @@
                 "Welcome, ": "欢迎，",
                 "the rules": "相关规则",
                 "AI Training Settings": "AI 训练设置",
-                "To continue providing the AtCoder contest platform free of charge to all users, starting in August 2026, AtCoder will license user-submitted source code to companies and organizations for the purpose of training AI models. You may opt out of this on both a per-user basis and a per-submission basis. If you do not want any of your submissions to be used for AI training or licensing, please enable the following setting:": "为了继续向所有用户免费提供 AtCoder 竞赛平台，从 2026 年 8 月起，AtCoder 会将用户提交的源代码授权给公司及组织，用于训练 AI 模型。您可以选择按用户或按每次提交退出此项许可。若您不希望自己的任何提交被用于 AI 训练或许可，请启用以下设置："
+                "To continue providing the AtCoder contest platform free of charge to all users, starting in August 2026, AtCoder will license user-submitted source code to companies and organizations for the purpose of training AI models. You may opt out of this on both a per-user basis and a per-submission basis. If you do not want any of your submissions to be used for AI training or licensing, please enable the following setting:": "为了继续向所有用户免费提供 AtCoder 竞赛平台，从 2026 年 8 月起，AtCoder 会将用户提交的源代码授权给公司及组织，用于训练 AI 模型。您可以选择按用户或按每次提交退出此项许可。若您不希望自己的任何提交被用于 AI 训练或许可，请启用以下设置：",
+                "Additionally, if you use generative AI in this contest, you must enter the instructions specified in the problem statement at the beginning of each chat, or configure them as custom instructions, project instructions, or in an instruction file that is automatically loaded by the generative AI tool": "此外，若您在本竞赛中使用生成式 AI，必须在每次对话开始时输入题目说明中指定的指令，或将其配置为自定义指令、项目指令，或存储在生成式 AI 工具会自动加载的指令文件中"
             }
         },
         ".lang-en": {


### PR DESCRIPTION
准确来说，后者是把原本用于个人资料Rating显示的“Algorithm”“Heuristic”的翻译范围限制到了`.nav.nav-tabs`这个范围（我看F12里这么写的应该这里也是这个语法），不然AHC的比赛标题`.nav.navbar-nav`也得遭殃，考虑未来把所有这种都加上`-tabs`。

（照样只改了英文……坑越挖越大了……/gg）